### PR TITLE
Make babel-jsxgettext work on node 0.10.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ var features = BABEL_FEATURES.reduce(function (result, key) {
   return result
 }, {})
 
+
+// Polyfill Object.setPrototypeOf
+Object.setPrototypeOf = Object.setPrototypeOf || function(obj, proto) {
+  obj.__proto__ = proto;
+  return obj;
+};
+
 /**
  * The parser function
  * @param  {String}   input  The path to soure JavaScript file

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,5 +1,5 @@
 var jsxBase = {
-  JSXElement (node, st, c) {
+    JSXElement: function (node, st, c) {
     node.openingElement.attributes.forEach(function (attr) {
       c(attr, st, attr.type)
     })
@@ -7,23 +7,24 @@ var jsxBase = {
       c(child, st, child.type)
     })
   },
-  JSXExpressionContainer (node, st, c) {
+  JSXExpressionContainer: function (node, st, c) {
     c(node.expression, st, node.expression.type)
   },
-  JSXAttribute (node, st, c) {
+  JSXAttribute: function (node, st, c) {
     if (node.value !== null) {
       c(node.value, st, node.value.type)
     }
   },
-  JSXSpreadAttribute (node, st, c) {
+  JSXSpreadAttribute: function (node, st, c) {
     c(node.argument, st, node.argument.type)
   },
-  ClassProperty (node, st, c) {
+  ClassProperty: function (node, st, c) {
     // console.log(node, st, c)
   },
-  BindExpression (node, st, c) {
-
-  }
+  BindExpression: function (node, st, c) {
+  },
+  JSXEmptyExpression: function () {
+  },
 }
 
 module.exports = jsxBase


### PR DESCRIPTION
Converts ES6 syntax in lib/index.js and adds a PolyFill for
`Object.setPrototypeOf`.

Reason behind this backport is that node 0.10.x comes as part of Ubuntu 14.04 LTS distribution, which is used in many build and production environments.
