### PR TITLE
Don't crash on JSX comments.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -23,6 +23,9 @@ var jsxBase = {
   },
   BindExpression (node, st, c) {
 
+  },
+  JSXEmptyExpression (node, st, c) {
+
   }
 }
 

--- a/test/test2.js
+++ b/test/test2.js
@@ -227,6 +227,7 @@ export default class Main extends Component {
           { !isFetchingTownships &&
             <div className={styles.action}>
               <span className={styles.preview}>{ gettext('New file name: ') } { `${!isFetchingTownships ? this.findTownshipById(townships, selectedTownship).pcode : ''}_${tract || ''}_${currentMeyo && currentMeyo.length > 0 ? currentMeyo.replace(/ /g, '-').replace(/_/g, '-') : ''}_${formType || ''}_${elections && election ? this.findElectionById(elections, election).pcode : ''}_Page${pageNumber || ''}.png` }</span>
+              {/* only valid meyo when is form 16 and form 16a */}
               <button disabled={!validName} className={styles.submit} type='submit'>{ gettext('Rename') }</button>
             </div>
           }


### PR DESCRIPTION
This PR updates a test file to exhibit the bug and proposes a fix.

Without the fix, I'm getting this stack trace:

```
babel-jsxgettext/node_modules/acorn/dist/walk.js:38
    base[type](node, st, c);
              ^

TypeError: base[type] is not a function
    at c (babel-jsxgettext/node_modules/acorn/dist/walk.js:38:15)
    at Object.JSXExpressionContainer (babel-jsxgettext/lib/base.js:11:5)
    at c (babel-jsxgettext/node_modules/acorn/dist/walk.js:38:15)
    at babel-jsxgettext/lib/base.js:7:7
    at Array.forEach (native)
    at Object.JSXElement (babel-jsxgettext/lib/base.js:6:19)
    at c (babel-jsxgettext/node_modules/acorn/dist/walk.js:38:15)
    at Object.skipThrough (babel-jsxgettext/node_modules/acorn/dist/walk.js:169:3)
    at c (babel-jsxgettext/node_modules/acorn/dist/walk.js:38:15)
    at Object.base.BinaryExpression.base.LogicalExpression (babel-jsxgettext/node_modules/acorn/dist/walk.js:317:3)
```
