### PR TITLE
es7 await expression support

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -26,6 +26,9 @@ var jsxBase = {
   },
   JSXEmptyExpression (node, st, c) {
 
+  },
+  AwaitExpression (node, st, c) {
+
   }
 }
 


### PR DESCRIPTION
Without this patch you'll get the error "base[type] is not a function" if you have in your code an await expression.
