### PR TITLE
addAlias() method to set new extraction markers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,4 +105,8 @@ function parser (inputs, output, cb) {
   })
 }
 
-module.exports = parser
+parser.addAlias = function(name, alias) {
+  functionNames[alias] = functionNames[name];
+}
+
+module.exports = parser;

--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ function parser (inputs, output, cb) {
   })
 }
 
-parser.addAlias = function(name, alias) {
-  functionNames[alias] = functionNames[name];
+parser.addAlias = function (name, alias) {
+  functionNames[alias] = functionNames[name]
 }
 
-module.exports = parser;
+module.exports = parser

--- a/lib/base.js
+++ b/lib/base.js
@@ -29,6 +29,12 @@ var jsxBase = {
   },
   AwaitExpression (node, st, c) {
 
+  },
+  SpreadProperty (node, st, c) {
+
+  },
+  Pattern (node, st, c) {
+
   }
 }
 


### PR DESCRIPTION
Usage:

```
    var parser = require('babel-jsxgettext')

    // add new alias for the "gettext" marker
    parser.addAlias('gettext', 'tr')

    // then use the parser function as usual
    parser(inputs, output, , function (err) {
      if (err) throw err
      console.log('Job completed!')
    })

```
