### PR TITLE
Upgrade babylon and using babylon-walk instead of Acorn

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var gettextParser = require('gettext-parser')
 var babylon = require('babylon')
-var walk = require('acorn/dist/walk')
+var walk = require('babylon-walk')
 
 var functionNames = require('./lib/constant').DEFAULT_FUNCTION_NAMES
 var DEFAULT_HEADERS = require('./lib/constant').DEFAULT_HEADERS
@@ -37,8 +37,6 @@ function parser (inputs, output, cb) {
 
   var nplurals = /nplurals ?= ?(\d)/.exec(headers['plural-forms'])[1]
 
-  Object.setPrototypeOf(jsxBase, walk.base)
-
   inputs
     .forEach(function (file) {
       var resolvedFilePath = path.join(process.cwd(), file)
@@ -47,7 +45,7 @@ function parser (inputs, output, cb) {
         allowHashBang: true,
         ecmaVersion: Infinity,
         sourceType: 'module',
-        plugins: { jsx: true },
+        plugins: ['jsx'],
         features: features
       })
 

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   },
   "homepage": "https://github.com/fraserxu/babel-jsxgettext#readme",
   "dependencies": {
-    "acorn": "^2.4.0",
-    "babylon": "^5.8.23",
-    "gettext-parser": "^1.1.1",
-    "meow": "^3.3.0"
+    "acorn": "^4.0.4",
+    "babylon": "^6.15.0",
+    "gettext-parser": "^1.2.2",
+    "meow": "^3.7.0"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.3",
+    "babel-eslint": "^7.1.1",
     "standard": "^5.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "homepage": "https://github.com/fraserxu/babel-jsxgettext#readme",
   "dependencies": {
-    "acorn": "^4.0.4",
     "babylon": "^6.15.0",
+    "babylon-walk": "^1.0.2",
     "gettext-parser": "^1.2.2",
     "meow": "^3.7.0"
   },


### PR DESCRIPTION
I was hitting problems with some of the latest language features so I upgraded Babylon to the latest version. In doing so the Acorn walker was unable to recognize some of the new features to I switched it to use babylon-walk, instead. Everything seems to work great now! (I confirmed that strings were extracted both from normal JS files and from inside JSX.)