### PR TITLE
CLI option to set plugins for babylon parser (updated)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,7 @@ var cli = meow({
   ].join('\n')
 })
 
-var plugins = cli.flags.plugins ? cli.flags.plugins.split(",") : null
+var plugins = cli.flags.plugins ? cli.flags.plugins.split(',') : null
 var inputs = cli.input.slice(0, cli.input.length - 1)
 var output = cli.flags.o || cli.flags.output || cli.input[cli.input.length - 1]
 output = path.join(process.cwd(), output)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,7 @@ var cli = meow({
   ].join('\n')
 })
 
-var plugins = cli.flags.plugins.split(",")
+var plugins = cli.flags.plugins ? cli.flags.plugins.split(",") : null
 var inputs = cli.input.slice(0, cli.input.length - 1)
 var output = cli.flags.o || cli.flags.output || cli.input[cli.input.length - 1]
 output = path.join(process.cwd(), output)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ var cli = meow({
     'Options',
     '  --help                     Show this help',
     '  --version                  Current version of package',
+    '  -p | --plugins             String - Babylon plugins list defualt [\'jsx\', \'classProperties\']',
     '  -i | --input               String - The path to soure JavaScript file',
     '  -o | --output              String - The path of the output PO file',
     '',
@@ -23,11 +24,12 @@ var cli = meow({
   ].join('\n')
 })
 
+var plugins = cli.flags.plugins.split(",")
 var inputs = cli.input.slice(0, cli.input.length - 1)
 var output = cli.flags.o || cli.flags.output || cli.input[cli.input.length - 1]
 output = path.join(process.cwd(), output)
 
-parser(inputs, output, function (err) {
+parser(inputs, output, plugins, function (err) {
   if (err) throw err
   console.log('Job completed!')
 })

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ var cli = meow({
     'Options',
     '  --help                     Show this help',
     '  --version                  Current version of package',
-    '  -p | --plugins             String - Babylon plugins list defualt [\'jsx\', \'classProperties\']',
+    '  -p | --plugins             String - Babylon plugins list (`jsx` is always included)',
     '  -i | --input               String - The path to soure JavaScript file',
     '  -o | --output              String - The path of the output PO file',
     '',
@@ -19,12 +19,13 @@ var cli = meow({
     '',
     'Examples',
     '  $ babel-jsxgettext ./test/*.js test.po',
+    '  $ babel-jsxgettext --plugins "classProperties,objectRestSpread" ./test/*.js test.po',
 
     ''
   ].join('\n')
 })
 
-var plugins = cli.flags.plugins ? cli.flags.plugins.split(',') : null
+var plugins = cli.flags.plugins ? cli.flags.plugins.split(',') : []
 var inputs = cli.input.slice(0, cli.input.length - 1)
 var output = cli.flags.o || cli.flags.output || cli.input[cli.input.length - 1]
 output = path.join(process.cwd(), output)

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var features = BABEL_FEATURES.reduce(function (result, key) {
  * @param  {String}   output The path of the output PO file
  * @param  {Function} cb     The callback function
  */
-function parser (inputs, output, cb) {
+function parser (inputs, output, plugins, cb) {
   var data = {
     charset: 'UTF-8',
     headers: DEFAULT_HEADERS,
@@ -45,7 +45,7 @@ function parser (inputs, output, cb) {
         allowHashBang: true,
         ecmaVersion: Infinity,
         sourceType: 'module',
-        plugins: ['jsx'],
+        plugins: plugins || ['jsx', 'classProperties'],
         features: features
       })
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function parser (inputs, output, plugins, cb) {
         allowHashBang: true,
         ecmaVersion: Infinity,
         sourceType: 'module',
-        plugins: plugins || ['jsx', 'classProperties'],
+        plugins: ['jsx'].concat(plugins),
         features: features
       })
 


### PR DESCRIPTION
A follow up to https://github.com/fraserxu/babel-jsxgettext/pull/8 - Adding to @yuri1992's work. 

My addition are:

1. Fixing the linting error
2. Always including `react` in the list of plugins, regardless of CLI options set

I've tested this branch locally - against our app that uses `babel-jsxgettext` and specifying plugins  fixes the problems we've had with experimental features not parsing. 👍 

