### PR TITLE
Log file + line/column for a parsing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,19 @@ function parser (inputs, output, plugins, cb) {
     .forEach(function (file) {
       var resolvedFilePath = path.join(process.cwd(), file)
       var src = fs.readFileSync(resolvedFilePath, 'utf8')
-      var ast = babylon.parse(src, {
-        allowHashBang: true,
-        ecmaVersion: Infinity,
-        sourceType: 'module',
-        plugins: ['jsx'].concat(plugins),
-        features: features
-      })
+
+      try {
+        var ast = babylon.parse(src, {
+          allowHashBang: true,
+          ecmaVersion: Infinity,
+          sourceType: 'module',
+          plugins: ['jsx'].concat(plugins),
+          features: features
+        })
+      } catch (e) {
+        console.error(`SyntaxError in ${file} (line: ${e.loc.line}, column: ${e.loc.column})`)
+        process.exit(1)
+      }
 
       walk.simple(ast.program, {
         CallExpression: function (node) {


### PR DESCRIPTION
Hiya!

While investigating some parsing errors (before #8/#9) we had to add console logging directly to this module to see which file had the parsing error. I imagine this'll be useful in the future, so I wanted to make it the default behaviour.

When a file can't be parsed (due to a legit syntax error, or a missing plugin for the experimental language feature) then it's helpful to see which file couldn't be parsed and at what point in that file.

Hopefully this is useful to you too :)