### PR TITLE
Upgrade babylon to Babel parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var parser = require('babel-jsxgettext')
  * The parser function
  * @param  {String}   input  The path to source JavaScript file
  * @param  {String}   output The path of the output PO file
- * @param  {String}   plugins Babel plugins, separate by `,`
+ * @param  {String}   plugins Babel parser plugins, separate by `,`
  * @param  {Function} cb     The callback function
  */
 parser(inputs, output, plugins, function (err) {
@@ -44,7 +44,7 @@ Install globally with npm `npm install babel-jsxgettext -g`
   Options
     --help                     Show this help
     --version                  Current version of package
-    -p | --plugins             String - Babylon plugins list (`jsx` is always included)'
+    -p | --plugins             String - Babel parser plugins list (`jsx` is always included)'
     -i | --input               String - The path to soure JavaScript file
     -o | --output              String - The path of the output PO file
 
@@ -62,7 +62,7 @@ Install globally with npm `npm install babel-jsxgettext -g`
 
 I'm Using Babel with React + JSX for most of my project, but there's no perfect and direct way to generate `.po` file from ES6 + JSX code(or from a directory).
 
-`acron-jsx` support `jsx` but not all the feature I use in Babel(ES7 etc.,). So I grab the `babylon` parser from Babel and use it to generate `.po` file.
+`acron-jsx` support `jsx` but not all the feature I use in Babel(ES7 etc.,). So I grab the [Babel parser](https://babeljs.io/docs/en/babel-parser) and use it to generate `.po` file.
 
 ### License
 MIT

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ var cli = meow({
     'Options',
     '  --help                     Show this help',
     '  --version                  Current version of package',
-    '  -p | --plugins             String - Babylon plugins list (`jsx` is always included)',
+    '  -p | --plugins             String - Babel parser plugins list (`jsx` is always included)',
     '  -i | --input               String - The path to soure JavaScript file',
     '  -o | --output              String - The path of the output PO file',
     '',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var gettextParser = require('gettext-parser')
-var babylon = require('babylon')
+var babelParser = require('@babel/parser')
 var walk = require('babylon-walk')
 
 var functionNames = require('./lib/constant').DEFAULT_FUNCTION_NAMES
@@ -36,9 +36,7 @@ function parser (inputs, output, plugins, cb) {
       var src = fs.readFileSync(resolvedFilePath, 'utf8')
 
       try {
-        var ast = babylon.parse(src, {
-          allowHashBang: true,
-          ecmaVersion: Infinity,
+        var ast = babelParser.parse(src, {
           sourceType: 'module',
           plugins: ['jsx'].concat(plugins)
         })

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/fraserxu/babel-jsxgettext#readme",
   "dependencies": {
-    "babylon": "^6.15.0",
+    "@babel/parser": "^7.1.0",
     "babylon-walk": "^1.0.2",
     "gettext-parser": "^1.2.2",
     "meow": "^3.7.0"


### PR DESCRIPTION
Upgrade the Babel parser dependency from `^6.15.0` ([babylon](https://github.com/babel/babylon)) to `^7.1.0` ([@babel/parser](https://github.com/babel/babel/tree/master/packages/babel-parser)).